### PR TITLE
There are a couple of references to a md/ folder, but I think it should be pres/ now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A dockerized version of the [Reveal JS](http://lab.hakim.se/reveal-js/#/) presen
 And open a browser to `http://localhost:8000` (use the IP of your VM if
 using boot2docker, which can be found by running `boot2docker ip`).
 
-To use your own slides, replace `/revealjs/md/slides.md` with your own slides
+To use your own slides, replace `/revealjs/pres/slides.md` with your own slides
 in Markdown format. The easiest way to do this is with the `-v` flag e.g:
 
-    docker run -d -p 8000:8000 -v /path/to/my/slides.md:/revealjs/md/slides.md amouat/revealjs:latest
+    docker run -d -p 8000:8000 -v /path/to/my/slides.md:/revealjs/pres/slides.md amouat/revealjs:latest
 
 You can use the the [test slides](https://raw.githubusercontent.com/amouat/revealjs-docker/master/test_slides.md) to get an idea for the formatting.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use straight HTML for the slides, mount the html at `/revealjs/in
 
 If you need to include other files e.g. images, keep them with the presentation file and just mount the directory e.g:
 
-    docker run -d -p 8000:8000 -v /my/slide/dir:/revealjs/md amouat/revealjs:latest
+    docker run -d -p 8000:8000 -v /my/slide/dir:/revealjs/pres amouat/revealjs:latest
 
 This project is *heavily* based on [Peter Parente's revealjs](https://github.com/parente/dockerfiles/tree/master/revealjs). This differences are that this version has an updated Dockerfile which uses the NodeJS official image and removes a problematic VOLUME command. 
 


### PR DESCRIPTION
Documentation was not updated for changes in https://github.com/amouat/revealjs-docker/commit/804d3d3572729de52879a9c98c4e32930fe0cc14 
